### PR TITLE
Fix: 修复使用 faiss 时，重启后知识库异常的问题

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_knowledge_base
 desc: 为AstrBot实现了一个简单的知识库,实现在对话过程中补充额外的知识
 help: 输入 /kb help 查看指令帮助
-version: v0.5.5
+version: v0.5.6
 author: lxfight
 repo: https://github.com/lxfight/astrbot_plugin_knowledge_base


### PR DESCRIPTION
## Summary by Sourcery

Handle missing LLM provider without raising errors and refactor Faiss vector store to use file ID paths instead of a filename_map to fix knowledge base errors after restart, along with minor code formatting cleanup and version bump.

Bug Fixes:
- Prevent missing LLM provider from causing crashes by disabling LLM gracefully when none is configured
- Resolve Faiss knowledge base inconsistencies after restart by removing filename_map and using file_id-based paths for collections

Enhancements:
- Clean up code formatting by unifying string quoting and trimming trailing whitespace

Chores:
- Bump plugin version from v0.5.5 to v0.5.6