### PR TITLE
切换 Markitdown 依赖

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,4 @@
 numpy>=2.2.0
 faiss-cpu>=1.10.0
 pymilvus>=2.5.0
-markitdown[all]>=0.1.0
-#markitdown-plugin 依赖
-pdf-to-markdown[async_sync_env]
-pymupdf
-pymupdf4llm
-pillow
-tqdm
+markitdown-no-magika[pptx,docx,xlsx,xls,pdf]

--- a/utils/installation.py
+++ b/utils/installation.py
@@ -140,7 +140,7 @@ def ensure_vector_db_dependencies(
         "numpy", ">=2.2.0", friendly_name="Numpy"
     )
     core_deps_ok &= _check_and_install_package_uv(
-        "markitdown[all]", ">=0.1.0", friendly_name="markitdown[all]"
+        "markitdown-no-magika[pptx,docx,xlsx,xls,pdf]", ">=0.1.0", friendly_name="markitdown-no-magika[pptx,docx,xlsx,xls,pdf]"
     )
 
     if not core_deps_ok:


### PR DESCRIPTION
- 移除 onnxruntime 依赖
- 移除 magika 依赖
- 移除不必要的其他依赖：

```
outlook = ["olefile"]
audio-transcription = ["pydub", "SpeechRecognition"]
youtube-transcription = ["youtube-transcript-api"]
az-doc-intel = ["azure-ai-documentintelligence", "azure-identity"]
```

## Summary by Sourcery

Switch the Markdown parsing dependency to markitdown-no-magika and prune related dependencies

Enhancements:
- Replace markitdown[all] and its plugins with markitdown-no-magika including only pptx, docx, xlsx, xls, and pdf support
- Remove magika and associated plugin packages from requirements.txt
- Update installation script to install markitdown-no-magika instead of markitdown[all]