### PR TITLE
Feature: 支持在 AstrBot 配置文件页直接配置默认知识库以及支持配置项条件判断显示

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -12,43 +12,62 @@
     "default_collection_name": {
         "description": "默认知识库集合名称",
         "type": "string",
-        "default": "general"
+        "default": "general",
+        "hint": "AstrBot 版本 >= v4.0.0 时，本配置项失效，请直接在 WebUI `配置文件` 页下配置知识库。"
     },
     "milvus_host": {
         "description": "Milvus 服务主机",
         "type": "string",
         "default": "localhost",
-        "hint": " (仅当 vector_db_type 为 'milvus' 时有效)"
+        "hint": " (仅当 vector_db_type 为 'milvus' 时有效)",
+        "condition": {
+            "vector_db_type": "milvus"
+        }
     },
     "milvus_port": {
         "description": "Milvus 服务端口",
         "type": "string",
         "default": "19530",
-        "hint": "(仅当 vector_db_type 为 'milvus' 时有效)"
+        "hint": "(仅当 vector_db_type 为 'milvus' 时有效)",
+        "condition": {
+            "vector_db_type": "milvus"
+        }
     },
     "milvus_user": {
         "description": "Milvus 用户名",
         "type": "string",
         "default": "",
-        "hint": "(可选, 仅当 vector_db_type 为 'milvus' 时有效)"
+        "hint": "(可选, 仅当 vector_db_type 为 'milvus' 时有效)",
+        "condition": {
+            "vector_db_type": "milvus"
+        }
     },
     "milvus_password": {
         "description": "Milvus 密码",
         "type": "string",
         "default": "",
-        "hint": "(可选, 仅当 vector_db_type 为 'milvus' 时有效)"
+        "hint": "(可选, 仅当 vector_db_type 为 'milvus' 时有效)",
+        "condition": {
+            "vector_db_type": "milvus"
+        }
     },
     "faiss_db_subpath": {
         "description": "Faiss 索引存储子路径 ",
         "type": "string",
         "default": "faiss_data",
-        "hint": "(相对于持久化数据目录 'AstrBot/data/plugins_data/astrbot_plugin_knowledge_base/', 仅当 vector_db_type 为 'faiss' 时有效)"
+        "hint": "(相对于持久化数据目录 'AstrBot/data/plugins_data/astrbot_plugin_knowledge_base/', 仅当 vector_db_type 为 'faiss' 时有效)",
+        "condition": {
+            "vector_db_type": "faiss"
+        }
     },
     "milvus_lite_db_subpath": {
         "description": "Milvus Lite 数据文件子路径 ",
         "type": "string",
         "default": "milvus_lite_data/milvus_lite.db",
-        "hint": "(相对于持久化数据目录 'AstrBot/data/plugins_data/astrbot_plugin_knowledge_base/', 仅当 vector_db_type 为 'milvus_lite' 时有效)"
+        "hint": "(相对于持久化数据目录 'AstrBot/data/plugins_data/astrbot_plugin_knowledge_base/', 仅当 vector_db_type 为 'milvus_lite' 时有效)",
+        "condition": {
+            "vector_db_type": "milvus_lite"
+        }
     },
     "text_chunk_size": {
         "description": "文本分块大小 (字符数)",

--- a/core/llm_enhancer.py
+++ b/core/llm_enhancer.py
@@ -78,18 +78,13 @@ async def enhance_request_with_kb(
     default_collection_name = user_prefs_handler.get_user_default_collection(event)
 
     if not default_collection_name:
-        logger.debug("未找到当前会话的默认知识库，跳过 LLM 请求增强。")
+        logger.debug("未找到当前会话的默认知识库，跳过知识库查询。")
         return
 
     if not await vector_db.collection_exists(default_collection_name):
         logger.warning(
-            f"用户默认知识库 '{default_collection_name}' 不存在，跳过 LLM 请求增强。"
+            f"知识库 '{default_collection_name}' 不存在，跳过知识库查询。"
         )
-        return
-
-    enable_kb_enhancement = plugin_config.get("enable_kb_llm_enhancement", True)
-    if not enable_kb_enhancement:
-        logger.info("知识库对LLM请求的增强功能已全局禁用。")
         return
 
     kb_search_top_k = plugin_config.get("kb_llm_search_top_k", 3)

--- a/core/user_prefs_handler.py
+++ b/core/user_prefs_handler.py
@@ -52,8 +52,7 @@ class UserPrefsHandler:
 
     def get_user_default_collection(self, event: AstrMessageEvent) -> str:
         user_key = event.unified_msg_origin
-        user_kb_perf = self.user_collection_preferences.get(user_key, None)
-        if user_kb_perf:
+        if user_kb_perf := self.user_collection_preferences.get(user_key, None):
             # 用户会话偏好优先
             return user_kb_perf
         if VERSION >= "4.0.0":

--- a/main.py
+++ b/main.py
@@ -78,7 +78,7 @@ class KnowledgeBasePlugin(Star):
             logger.info("知识库插件开始初始化...")
             # User Preferences Handler
             self.user_prefs_handler = UserPrefsHandler(
-                self.user_prefs_path, self.vector_db, self.config
+                self.user_prefs_path, self.vector_db, self.config, self.context
             )
             await self.user_prefs_handler.load_user_preferences()
 


### PR DESCRIPTION
支持用户更方便地在 WebUI 选择知识库，默认知识库的选择可以跟随配置文件来在不同会话（目前暂时是不同消息平台）做隔离。

Note:

1. 需要等待 AstrBot 发布 v4.0.0 之后更改才会生效。
2.  v4.0.0 后，知识库插件配置项中的 “默认知识库集合名称” 将失效。
3. 本更改仅修改了“默认知识库的选择”，知识库插件中原来的用户自行选择的知识库偏好仍然生效，并且优先级最高。

## Summary by Sourcery

Add support for configuring the default knowledge base per session directly from the AstrBot configuration, with version-aware fallbacks for backwards compatibility and streamlined command and enhancer logic.

New Features:
- Allow default knowledge base selection to be driven by AstrBot’s v4.0.0+ configuration on a per-session basis
- Inject Context into UserPrefsHandler to fetch session-scoped default_kb_collection settings

Enhancements:
- Introduce a shared helper for retrieving the default collection name and apply it in manage_commands and deletion logic
- Adjust llm_enhancer logging to refer to knowledge base queries and remove the global enhancement toggle check
- Pass Context into the main initialization to support the new configuration flow